### PR TITLE
Rename transaction_types and transaction_count for consistency

### DIFF
--- a/hooks/blocks/useBlockTransactions.ts
+++ b/hooks/blocks/useBlockTransactions.ts
@@ -22,7 +22,7 @@ export type Transaction = {
     base_fee_per_gas: string;
     from: Address;
     token_transfers: TokenTransfer[];
-    transaction_types: string[];
+    tx_types: string[];
     gas_used: string;
     created_contract: Address;
     position: number;

--- a/hooks/main/useMainTransactions.ts
+++ b/hooks/main/useMainTransactions.ts
@@ -22,7 +22,7 @@ export type Transaction = {
     base_fee_per_gas: string;
     from: Address;
     token_transfers: TokenTransfer[];
-    transaction_types: string[];
+    tx_types?: string[];
     gas_used: string;
     created_contract: Address;
     position: number;

--- a/hooks/stats/useStatsChartTxs.ts
+++ b/hooks/stats/useStatsChartTxs.ts
@@ -17,14 +17,13 @@ export default function useStatsChartTxs() {
                     'Content-Type': 'application/json',
                 },
             });
-
             const response_json = response.data;
 
             const labels = response_json.chart_data.map(
                 (data: { date: string }) => data.date,
             );
             const transactionCounts = response_json.chart_data.map(
-                (data: { transaction_count: string }) => data.transaction_count,
+                (data: { tx_count: string }) => data.tx_count,
             );
 
             setLabels(labels);

--- a/hooks/transactions/useTransactionDetails.ts
+++ b/hooks/transactions/useTransactionDetails.ts
@@ -23,7 +23,7 @@ export type Transaction = {
     base_fee_per_gas: string;
     from: Address;
     token_transfers: TokenTransfer[];
-    transaction_types: string[];
+    tx_types: string[];
     gas_used: string;
     created_contract: Address;
     position: number;

--- a/hooks/transactions/useTransactions.ts
+++ b/hooks/transactions/useTransactions.ts
@@ -23,7 +23,7 @@ export type Transaction = {
     base_fee_per_gas: string;
     from: Address;
     token_transfers: TokenTransfer[];
-    transaction_types: string[];
+    tx_types: string[];
     gas_used: string;
     created_contract: Address;
     position: number;

--- a/ui/shared/transactions/details/container.tsx
+++ b/ui/shared/transactions/details/container.tsx
@@ -103,7 +103,7 @@ export default function TransactionDetailsContainer(props: {
                                                     )))
                                     }
                                     valueClassName="font-semibold"
-                                    href={`/address/${transactionDetails?.transaction_types.includes('contract_creation') ? transactionDetails?.created_contract.hash : transactionDetails?.to.hash}`}
+                                    href={`/address/${transactionDetails?.tx_types.includes('contract_creation') ? transactionDetails?.created_contract.hash : transactionDetails?.to.hash}`}
                                     isCopiable
                                 />
                             </div>

--- a/ui/shared/transactions/item.tsx
+++ b/ui/shared/transactions/item.tsx
@@ -32,7 +32,7 @@ export default function TransactionItem(props: { transaction: Transaction }) {
                     <div className="flex gap-2 justify-self-start mr-auto">
                         <h4 className="text-sm font-semibold">To:</h4>
                         <p className="text-sm text-text-primary font-semibold">
-                            {props.transaction.transaction_types.includes(
+                            {props.transaction.tx_types && props.transaction.tx_types.includes(
                                 'contract_creation',
                             )
                                 ? 'Contract Creation'


### PR DESCRIPTION
Rename `transaction_types` to `tx_types` and `transaction_count` to `tx_count` to ensure consistency across transaction handling in the codebase.